### PR TITLE
Cache mvn packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,30 @@ COPY --chown=1000:1000 copy.sh $HOME
 COPY --chown=1000:1000 rename.sh $HOME
 RUN chmod u+x $SERVER_HOME/bin/*.sh
 
+
+# Pre download Maven packages to speed up Geppetto builds
+ENV \
+  ALPHA=v0.4.2-alpha \
+  GEPPETTO=https://github.com/openworm/org.geppetto.git \
+  MODEL=https://github.com/openworm/org.geppetto.model.git \
+  CORE=https://github.com/openworm/org.geppetto.core.git \
+  NEUROML=https://github.com/openworm/org.geppetto.model.neuroml.git \
+  SIM=https://github.com/openworm/org.geppetto.simulation.git \
+  FRONTEND=https://github.com/openworm/org.geppetto.frontend.git 
+
+RUN mkdir /tmp/delete
+WORKDIR /tmp/delete
+
+RUN \
+  for i in ${GEPPETTO} ${MODEL} ${CORE} ${NEUROML} ${SIM} ${FRONTEND} ;\
+  do \
+    git clone -b ${ALPHA} $i ;\
+  done &&\
+  cd org.geppetto &&\
+  mvn -Dhttps.protocols=TLSv1.2 -Dmaven.test.skip install &&\
+  cd ${HOME} &&\
+  rm -rf /tmp/delete
+
+WORKDIR $HOME
+
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
This makes travis and codefresh builds for geppetto faster by caching mvn packages